### PR TITLE
warning for metasploit .. 

### DIFF
--- a/unicorn.py
+++ b/unicorn.py
@@ -435,6 +435,9 @@ try:
     payload = ""
     ps1path = ""
 
+	if not os.popen("msfvenom -h").read():
+		sys.exit("\nPlease install metasploit first.\n")
+
     if len(sys.argv) > 1:
         if sys.argv[1] == "--help":
             ps_help()


### PR DESCRIPTION
Its working even metasploit not installed, because Popen not raise any error even if command not exists.Ex:

    import subprocess
    proc = subprocess.Popen(
	"msfvenom -p %s %s %s StagerURILength=5 StagerVerifySSLCert=false -e x86/shikata_ga_nai -a x86 --platform windows --smallest -f c" % (
		"test", "test", "test"), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
    data = proc.communicate()[0]
    if not data:
	    print ("NULL OUTPUT")

So its creating payload without shellcode and of course its not working.