### PR TITLE
Fix msfvenom check

### DIFF
--- a/unicorn.py
+++ b/unicorn.py
@@ -313,6 +313,8 @@ def generate_shellcode(payload, ipaddr, port):
         "msfvenom -p %s %s %s StagerURILength=5 StagerVerifySSLCert=false -e x86/shikata_ga_nai -a x86 --platform windows --smallest -f c" % (
             payload, ipaddr, port), stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
     data = proc.communicate()[0]
+    if not data:
+    	sys.exit('\nYou must install Metasploit Framework to generate shellcode.\n')
     # start to format this a bit to get it ready
     repls = {';': '', ' ': '', '+': '', '"': '', '\n': '', 'buf=': '', 'Found 0 compatible encoders': '',
              'unsignedcharbuf[]=': ''}
@@ -434,9 +436,6 @@ try:
     attack_modifier = ""
     payload = ""
     ps1path = ""
-
-	if not os.popen("msfvenom -h").read():
-		sys.exit("\nPlease install metasploit first.\n")
 
     if len(sys.argv) > 1:
         if sys.argv[1] == "--help":


### PR DESCRIPTION
Commit #60ea3bc broke the application with an unexpected indent error. After fixing the indent error, the new code caused the application to print the output of 'msfvenom -h' and 'please install metasploit.' before the rest of the program could be allowed to execute.  I slightly tweaked and moved the code to a more appropriate place in the application.