### PR TITLE
Fix missing 'file' reference for custom shellcode

### DIFF
--- a/unicorn.py
+++ b/unicorn.py
@@ -1225,7 +1225,7 @@ try:
         if not os.path.isfile(sys.argv[1]): 
             print("[!] File not found. Check the path and try again.")
             sys.exit()
-        payload = file(sys.argv[1], "r").read()
+        payload = open(sys.argv[1], "r").read()
 
         if attack_type == "cs":
             #if not "char buf[] =" in payload:


### PR DESCRIPTION
Unicorn complains about a missing 'file' ref when generating using custom shellcode, because 'file' should be 'open()'.

Never done a PR before, hopefully did this correctly.