### PR TITLE
Removed duplicate hta messages

### DIFF
--- a/unicorn.py
+++ b/unicorn.py
@@ -1162,8 +1162,6 @@ def format_payload(powershell_code, attack_type, attack_modifier, option):
     if attack_type == "msf" and attack_modifier == "hta":
         print("[*] Exported index.html, Launcher.hta, and unicorn.rc under hta_attack/.")
         print("[*] Run msfconsole -r unicorn.rc to launch listener and move index and launcher to web server.\n")
-        print("[*] Exported index.html, Launcher.hta, and unicorn.rc under hta_attack/.")
-        print("[*] Run msfconsole -r unicorn.rc to launch listener and move index and launcher to web server.\n")
 
     elif attack_type == "msf" or attack_type =="download/exec":
         print("[*] Exported powershell output code to powershell_attack.txt.")


### PR DESCRIPTION
Before:
```
[*] Exported index.html, Launcher.hta, and unicorn.rc under hta_attack/.
[*] Run msfconsole -r unicorn.rc to launch listener and move index and launcher to web server.

[*] Exported index.html, Launcher.hta, and unicorn.rc under hta_attack/.
[*] Run msfconsole -r unicorn.rc to launch listener and move index and launcher to web server.
```

After:
```
[*] Exported index.html, Launcher.hta, and unicorn.rc under hta_attack/.
[*] Run msfconsole -r unicorn.rc to launch listener and move index and launcher to web server.
```

It's either twice or half as good, depending on your point of view.